### PR TITLE
Support setext-style headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,33 @@ class MarkdownToc {
             let level = NaN;
             let title = null;
 
+            // Check for:
+            // 1. ATX-style headers: ## My Header
+            //
+            // 2. Setext-style headers:
+            //     a) Level 1 header: My Header
+            //                        =========
+            //
+            //     b) Level 2 header: My Header
+            //                        ---------
+            //
+            //    Edge cases that do not count as headers:
+            //     i) Horizontal rule ("Underline" preceded by empty line):
+            //
+            //           Some paragraph 1
+            //           <empty line>
+            //           -----
+            //           Some paragraph 2
+            //
+            //     ii) Two or more horizontal rules:
+            //
+            //           Some paragraph 1
+            //
+            //           -----
+            //           -----
+            //           -----
+            //           Some paragraph 2
+
             if (trimmed.startsWith("#")) {
                 const match = trimmed.match(/(#+)\s*(.*?)#*\s*$/);
                 level = match[1].length;

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ class MarkdownToc {
                 }
             }
 
-            if (level != NaN && title != null) {
+            if (!isNaN(level) && title != null) {
                 if (isNaN(topLevel)) {
                     topLevel = level;
                 }


### PR DESCRIPTION
For example:

```markdown
Minetest Lua Modding API Reference
==================================

* More information at <http://www.minetest.net/>
* Developer Wiki: <http://dev.minetest.net/>
* (Unofficial) Minetest Modding Book by rubenwardy: <https://rubenwardy.com/minetest_modding_book/>

Introduction
------------

Content and functionality can be added to Minetest using Lua scripting
in run-time loaded mods.
```
